### PR TITLE
Added Reflection. Empty strings count as nils enum assignemnt

### DIFF
--- a/lib/power_enum.rb
+++ b/lib/power_enum.rb
@@ -7,6 +7,7 @@ class PowerEnum < Rails::Engine
     ActiveSupport.on_load(:active_record) do
       include ActiveRecord::Acts::Enumerated
       include ActiveRecord::Aggregations::HasEnumerated
+      include PowerEnum::Reflection
 
       ActiveRecord::ConnectionAdapters.module_eval do
         include PowerEnum::Schema::SchemaStatements

--- a/lib/power_enum/reflection.rb
+++ b/lib/power_enum/reflection.rb
@@ -1,0 +1,27 @@
+module PowerEnum::Reflection
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def reflect_on_all_enumerated
+      reflections.values.grep(EnumerationReflection)
+    end
+
+    def reflect_on_enumerated enumerated
+      reflections[enumerated.to_sym].is_a?(EnumerationReflection) ? reflections[enumerated.to_sym] : nil
+    end
+  end
+
+  class EnumerationReflection < ActiveRecord::Reflection::MacroReflection
+    def initialize name, options, active_record
+      super :has_enumerated, name, options, active_record
+    end
+    
+    def class_name
+      @class_name ||= (@options[:class_name] || @name).to_s.camelize
+    end
+    
+    def foreign_key
+      @foreign_key ||= (@options[:foreign_key] || "#{@name}_id").to_s
+    end
+  end
+end

--- a/power_enum.gemspec
+++ b/power_enum.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     "lib/generators/enum/templates/rails31_migration.rb.erb",
     "lib/power_enum.rb",
     "lib/power_enum/migration/command_recorder.rb",
-    "lib/power_enum/schema/schema_statements.rb"
+    "lib/power_enum/schema/schema_statements.rb",
     "lib/power_enum/reflection.rb"
   ]
   s.homepage = "http://github.com/albertosaurus/enumerations_mixin"

--- a/power_enum.gemspec
+++ b/power_enum.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
     "lib/power_enum.rb",
     "lib/power_enum/migration/command_recorder.rb",
     "lib/power_enum/schema/schema_statements.rb"
+    "lib/power_enum/reflection.rb"
   ]
   s.homepage = "http://github.com/albertosaurus/enumerations_mixin"
   s.require_paths = ["lib"]


### PR DESCRIPTION
Added Reflections to make it possible to access arguments passed to has_enumerated declaration.

Modified enum assignment for easier handling parameters passed from form, for example
booking.update_attributes(:status => '') # will assign nil to status, instead of raising error
