### PR TITLE
Do not override `name` method.

### DIFF
--- a/spec/dummy/app/models/country.rb
+++ b/spec/dummy/app/models/country.rb
@@ -1,0 +1,3 @@
+class Country < ActiveRecord::Base
+  acts_as_enumerated :name_column => :code
+end

--- a/spec/dummy/db/migrate/20120707182546_create_enum_country.rb
+++ b/spec/dummy/db/migrate/20120707182546_create_enum_country.rb
@@ -1,0 +1,9 @@
+class CreateEnumCountry < ActiveRecord::Migration
+
+  def change
+    create_enum(:country, :name_column => :code, :name_limit => 2) do |t|
+      t.string :name, :null => false
+    end
+  end
+
+end

--- a/spec/dummy/db/migrate/20120707182920_populate_countries.rb
+++ b/spec/dummy/db/migrate/20120707182920_populate_countries.rb
@@ -1,0 +1,11 @@
+class PopulateCountries < ActiveRecord::Migration
+  def up
+    Country.enumeration_model_updates_permitted = true
+    Country.create!(:name => "Ukraine", :code => "ua")
+  end
+
+  def down
+    Country.enumeration_model_updates_permitted = true
+    Country.destroy_all
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120229205305) do
+ActiveRecord::Schema.define(:version => 20120707182920) do
 
   create_table "adapters", :force => true do |t|
     t.integer  "connector_type_id"
@@ -42,6 +42,13 @@ ActiveRecord::Schema.define(:version => 20120229205305) do
   end
 
   add_index "connector_types", ["name"], :name => "index_connector_types_on_name", :unique => true
+
+  create_table "countries", :force => true do |t|
+    t.string "code", :limit => 2, :null => false
+    t.string "name",              :null => false
+  end
+
+  add_index "countries", ["code"], :name => "index_countries_on_code", :unique => true
 
   create_table "states", :force => true do |t|
     t.string   "state_code"

--- a/spec/functional/acts_as_enumerated_spec.rb
+++ b/spec/functional/acts_as_enumerated_spec.rb
@@ -34,7 +34,7 @@ describe 'acts_as_enumerated' do
           status.name.should == 'confirmed'
           status.name_sym.should == :confirmed
         end
-        
+
       end
 
       context ':name_column is specified' do
@@ -85,7 +85,7 @@ describe 'acts_as_enumerated' do
         end
       end
     end
-    
+
     it 'returns instance when instance is passed' do
       state = State[1]
       state2 = State[state]
@@ -204,6 +204,12 @@ describe 'acts_as_enumerated' do
     context ':name_column is specified to be :state_code' do
       it 'name_column should be :state_code' do
         State.name_column.should == :state_code
+      end
+    end
+
+    context 'column "name" exists"' do
+      it 'should not override #name method"' do
+        Country[:ua].name.should == "Ukraine"
       end
     end
   end


### PR DESCRIPTION
When I have an enumerated model with column `name` and option `:name_column => :something_other` I can't access value of `name` since it returns value of `something_other`.
This patch fixes the issue. I also write a spec. Sorry for removed trailing spaces.
