### PR TITLE
Add enumerations as associations

### DIFF
--- a/lib/power_enum/reflection.rb
+++ b/lib/power_enum/reflection.rb
@@ -5,6 +5,13 @@ module PowerEnum::Reflection
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def self.extended(base)
+      class << base
+        alias_method_chain :reflect_on_all_associations, :enumeration
+        alias_method_chain :reflect_on_association, :enumeration
+      end
+    end
+
     def reflect_on_all_enumerated
       # Need to give it a full namespace to avoid getting Rails confused in development
       # mode where all objects are reloaded on every request.
@@ -13,6 +20,16 @@ module PowerEnum::Reflection
 
     def reflect_on_enumerated( enumerated )
       reflections[enumerated.to_sym].is_a?(PowerEnum::Reflection::EnumerationReflection) ? reflections[enumerated.to_sym] : nil
+    end
+
+    # Extend associations with enumerations, preferring enumerations
+    def reflect_on_all_associations_with_enumeration
+      reflect_on_all_enumerated + reflect_on_all_associations_without_enumeration
+    end
+
+    # Extend associations with enumerations, preferring enumerations
+    def reflect_on_association_with_enumeration( associated )
+      reflect_on_enumerated(associated) || reflect_on_association_without_enumeration(associated)
     end
   end
 

--- a/spec/functional/has_enumerated_spec.rb
+++ b/spec/functional/has_enumerated_spec.rb
@@ -26,9 +26,18 @@ describe 'has_enumerated' do
     Booking.reflect_on_all_enumerated.map(&:name).to_set.should == [:state, :status].to_set
   end
 
+  it 'should include enumerations as associations' do
+    Booking.reflect_on_all_associations.map(&:name).to_set.should == [:state, :status].to_set
+  end
+
   it 'should have reflection on has_enumerated association' do
     Booking.reflect_on_enumerated(:state).should_not be_nil
     Booking.reflect_on_enumerated('status').should_not be_nil
+  end
+
+  it 'should have reflection on association' do
+    Booking.reflect_on_association(:state).should_not be_nil
+    Booking.reflect_on_association('status').should_not be_nil
   end
 
   it 'should have reflection properly built' do


### PR DESCRIPTION
This allows power_enum to play nicely with tools like ActiveAdmin which
look at associations and have no idea about enumerations. Since
enumerations act like belongs_to associations, this works for such
tools.
