### PR TITLE
Make enumerated models always cache ALL records

### DIFF
--- a/lib/power_enum/enumerated.rb
+++ b/lib/power_enum/enumerated.rb
@@ -281,8 +281,8 @@ module PowerEnum::Enumerated
 
     def load_all
       conditions = self.acts_enumerated_conditions
-      order = self.acts_enumerated_order
-      where(conditions).order(order)
+      order      = self.acts_enumerated_order
+      unscoped.where(conditions).order(order)
     end
     private :load_all
 

--- a/spec/functional/acts_as_enumerated_spec.rb
+++ b/spec/functional/acts_as_enumerated_spec.rb
@@ -102,7 +102,7 @@ describe 'acts_as_enumerated' do
           status.__enum_name__.should == 'confirmed'
           status.name_sym.should == :confirmed
         end
-        
+
       end
 
       context ':name_column is specified' do
@@ -192,7 +192,7 @@ describe 'acts_as_enumerated' do
         end
       end
     end
-    
+
     it 'returns instance when instance is passed' do
       state = State[1]
       state2 = State[state]
@@ -605,5 +605,31 @@ describe 'acts_as_enumerated' do
     it 'models which are not enums should not act as enumerated' do
       Booking.acts_as_enumerated?.should == false
     end
+  end
+
+  context 'using class method as scopes' do
+    before { State.enumeration_model_updates_permitted = true  }
+    after  { State.enumeration_model_updates_permitted = false }
+
+    it 'with .active method' do
+      State.count.should == 3
+      State.purge_enumerations_cache
+
+      # .acitve may call redefined .all which caches only values with passed scope(not all)
+      State.where(:state_code => "IL").active
+
+      State.all.size.should == 3
+    end
+
+    it 'with .inactive method' do
+      State.count.should == 3
+      State.purge_enumerations_cache
+
+      # .inacitve may call redefined .all which caches only values with passed scope(not all)
+      State.where(:state_code => "IL").inactive
+
+      State.all.size.should == 3
+    end
+
   end
 end


### PR DESCRIPTION
When Enumerated loads data first time it caches them. And if scope was predefined it caches NOT ALL data, only which are returned.

See specs.

If data is not cached `@all = nil`, the next will cause caching only returned data(IL state).

``` ruby
State.where(:state_code => "IL").active 
```

I fixed that by update `load_all` with next line:

``` ruby
unscoped.where(conditions).order(order) 
```

However some proble remains.
`.active` is not a scope, it doesn't return relation and it relies on cached values.
I'd like to prevent those methods to be used as scope, but don't know how.
I opened question about it In StackOverflaw: http://stackoverflow.com/questions/16544217/activerecord-class-methods-without-scoping
