### PR TITLE
Conform to model generators for extra behavior

### DIFF
--- a/lib/generators/enum/enum_generator.rb
+++ b/lib/generators/enum/enum_generator.rb
@@ -2,12 +2,12 @@
 # Released under the MIT license.  See LICENSE for details.
 
 # Generator for PowerEnum
-class EnumGenerator < Rails::Generators::Base
+class EnumGenerator < Rails::Generators::NamedBase
   require File.expand_path('../enum_generator_helpers/migration_number', __FILE__)
-  include EnumGeneratorHelpers::MigrationNumber
+  include Rails::Generators::Migration
+  extend EnumGeneratorHelpers::MigrationNumber
 
   source_root File.expand_path('../templates', __FILE__)
-  argument :enum_name, :type => :string
   class_option :migration, :type => :boolean, :default => true, :desc => 'Generate migration for the enum'
   class_option :fixture, :type => :boolean, :default => false, :desc => 'Generate fixture for the enum'
 
@@ -18,45 +18,17 @@ class EnumGenerator < Rails::Generators::Base
 
   # Generates the migration to create the enum table.
   def generate_migration
-    template migration_template, "db/migrate/#{migration_file_name}.rb" if options.migration?
+    migration_template 'rails31_migration.rb.erb', "db/migrate/create_enum_#{table_name}.rb" if options.migration?
+  end
+
+  # Do not pluralize enumeration names
+  def pluralize_table_names?
+    false
   end
 
   hook_for :test_framework, :as => :model do |enum_generator_instance, test_generator_class|
     # Need to do this because I'm changing the default value of the 'fixture' option.
-    enum_generator_instance.invoke( test_generator_class, [enum_generator_instance.enum_name], { 'fixture' => enum_generator_instance.options.fixture? } )
-  end
-  
-  no_tasks do
-
-    # Returns the file name of the enum model without the .rb extension.
-    def file_name
-      enum_name.underscore
-    end
-
-    # Returns the class name of the enum.
-    def enum_class_name
-      file_name.camelize
-    end
-
-    # Derives the name for the migration, something like 'create_enum_fruit'
-    def migration_name
-      "create_enum_#{file_name}"
-    end
-
-    # Returns the class name of our migration
-    def migration_class_name
-      migration_name.camelize
-    end
-
-    # Generates and returns the filename of our migration
-    def migration_file_name
-      "#{next_migration_number}_#{migration_name}"
-    end
-
-    # Returns the name of the template file for the migration.
-    def migration_template
-      'rails31_migration.rb.erb'
-    end
-
+    table_name = enum_generator_instance.send(:table_name)
+    enum_generator_instance.invoke( test_generator_class, [table_name], { 'fixture' => enum_generator_instance.options.fixture? } )
   end
 end

--- a/lib/generators/enum/enum_generator_helpers/migration_number.rb
+++ b/lib/generators/enum/enum_generator_helpers/migration_number.rb
@@ -2,20 +2,10 @@
 module EnumGeneratorHelpers
   # Helper methods to figure out the migration number.
   module MigrationNumber
-
-    # Returns the number of the last migration.
-    # @return [Fixnum]
-    def current_migration_number(dirname = nil)
-      dirname ||= "#{Rails.root}/db/migrate/[0-9]*_*.rb"
-      Dir.glob(dirname).collect do |file|
-        File.basename(file).split("_").first.to_i
-      end.max.to_i
-    end
-
     # Returns the next upcoming migration number.  Sadly, Rails has no API for
     # this, so we're reduced to copying from ActiveRecord::Generators::Migration
     # @return [Fixnum]
-    def next_migration_number(dirname = nil)
+    def next_migration_number(dirname)
       # Lifted directly from ActiveRecord::Generators::Migration
       # Unfortunately, no API is provided by Rails at this time.
       next_migration_number = current_migration_number(dirname) + 1

--- a/lib/generators/enum/enum_generator_helpers/migration_number.rb
+++ b/lib/generators/enum/enum_generator_helpers/migration_number.rb
@@ -5,8 +5,8 @@ module EnumGeneratorHelpers
 
     # Returns the number of the last migration.
     # @return [Fixnum]
-    def current_migration_number
-      dirname = "#{Rails.root}/db/migrate/[0-9]*_*.rb"
+    def current_migration_number(dirname = nil)
+      dirname ||= "#{Rails.root}/db/migrate/[0-9]*_*.rb"
       Dir.glob(dirname).collect do |file|
         File.basename(file).split("_").first.to_i
       end.max.to_i
@@ -15,10 +15,10 @@ module EnumGeneratorHelpers
     # Returns the next upcoming migration number.  Sadly, Rails has no API for
     # this, so we're reduced to copying from ActiveRecord::Generators::Migration
     # @return [Fixnum]
-    def next_migration_number
+    def next_migration_number(dirname = nil)
       # Lifted directly from ActiveRecord::Generators::Migration
       # Unfortunately, no API is provided by Rails at this time.
-      next_migration_number = current_migration_number + 1
+      next_migration_number = current_migration_number(dirname) + 1
       if ActiveRecord::Base.timestamped_migrations
         [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % next_migration_number].max
       else

--- a/lib/generators/enum/templates/model.rb.erb
+++ b/lib/generators/enum/templates/model.rb.erb
@@ -1,3 +1,3 @@
-class <%= enum_class_name %> < ActiveRecord::Base
+class <%= class_name %> < ActiveRecord::Base
   acts_as_enumerated
 end

--- a/spec/generators/enum_gen_spec.rb
+++ b/spec/generators/enum_gen_spec.rb
@@ -8,7 +8,7 @@ describe :enum do
 
   context 'no arguments or options' do
     it 'should generate an error message' do
-      subject.should output("No value provided for required arguments 'enum_name'")
+      subject.should output("No value provided for required arguments 'name'")
     end
   end
 

--- a/spec/generators/enum_generator_helpers/migration_number_spec.rb
+++ b/spec/generators/enum_generator_helpers/migration_number_spec.rb
@@ -8,17 +8,18 @@ end
 
 describe EnumGeneratorHelpers::MigrationNumber do
   let(:helper) { MigrationStub.new }
+  let(:dirname) { "#{Rails.root}/db/migrate/[0-9]*_*.rb" }
 
   it 'non-timestamp migration number' do
     helper.should_receive(:current_migration_number).and_return(5)
     ActiveRecord::Base.should_receive(:timestamped_migrations).and_return(false)
 
-    helper.next_migration_number.should eq('006')
+    helper.next_migration_number(dirname).should eq('006')
   end
 
   it 'timestamp migration number' do
     helper.should_receive(:current_migration_number).and_return(90000000000001)
 
-    helper.next_migration_number.should eq('90000000000002')
+    helper.next_migration_number(dirname).should eq('90000000000002')
   end
 end


### PR DESCRIPTION
While re-running a bootstrapping script that uses generators, I noticed that I could safely re-run the defacto model generators from active record, but not the enum generators.

I found that there was a bit of custom behavior in place to mimic what `NamedBase` was already providing the `Migration` generator in active record, so I switched to `NamedBase` as a superclass.

```
Finished in 14.63 seconds
182 examples, 0 failures

Randomized with seed 16369

Coverage report generated for RSpec to /home/zbelzer/repos/power_enum/coverage. 469 / 471 LOC (99.58%) covered.
```
