### PR TITLE
Fix rspec deprecation warnings

### DIFF
--- a/lib/testing/rspec.rb
+++ b/lib/testing/rspec.rb
@@ -87,7 +87,7 @@ if defined? RSpec
       end
     end
 
-    failure_message_for_should do
+    failure_message do
       message = "should act as enumerated"
       if @items
         message << " and have members #{@items.inspect}"
@@ -95,7 +95,7 @@ if defined? RSpec
       message
     end
 
-    failure_message_for_should_not do
+    failure_message_when_negated do
       message = "should not act as enumerated"
       if @items
         message << " with members #{@items.inspect}"


### PR DESCRIPTION
Using the rspec test helpers was previously displaying the following
message:

```
Deprecation Warnings:

`failure_message_for_should_not` is deprecated. Use `failure_message_when_negated` instead. Called from /usr/lib/ruby/gems/2.1.0/gems/po
wer_enum-2.7.1/lib/testing/rspec.rb:98:in `block in <top (required)>'.

`failure_message_for_should` is deprecated. Use `failure_message` instead. Called from /usr/lib/ruby/gems/2.1.0/gems/power_enum-2.7.1/li
b/testing/rspec.rb:90:in `block in <top (required)>'.

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total
```
